### PR TITLE
Fix: No matching distribution found for en_core_web_sm

### DIFF
--- a/subject_verb_object_extract.py
+++ b/subject_verb_object_extract.py
@@ -18,13 +18,13 @@ from collections.abc import Iterable
 
 # use spacy small model
 try:
-    nlp = spacy.load('en')
+    nlp = spacy.load('en_core_web_sm')
 except OSError:
     print('Downloading language model for the spaCy POS tagger\n'
         "(don't worry, this will only happen once)", file=sys.stderr)
     from spacy.cli import download
-    download('en')
-    nlp = spacy.load('en')
+    download('en_core_web_sm')
+    nlp = spacy.load('en_core_web_sm')
 
 # dependency markers for subjects
 SUBJECTS = {"nsubj", "nsubjpass", "csubj", "csubjpass", "agent", "expl"}
@@ -333,4 +333,3 @@ def findSVOs(tokens):
                                      "!" + v.lower_ if verbNegated else v.lower_,))
 
     return svos
-

--- a/subject_verb_object_extract.py
+++ b/subject_verb_object_extract.py
@@ -13,10 +13,18 @@
 # limitations under the License.
 
 import spacy
+import sys
 from collections.abc import Iterable
 
 # use spacy small model
-nlp = spacy.load('en_core_web_sm')
+try:
+    nlp = spacy.load('en')
+except OSError:
+    print('Downloading language model for the spaCy POS tagger\n'
+        "(don't worry, this will only happen once)", file=sys.stderr)
+    from spacy.cli import download
+    download('en')
+    nlp = spacy.load('en')
 
 # dependency markers for subjects
 SUBJECTS = {"nsubj", "nsubjpass", "csubj", "csubjpass", "agent", "expl"}


### PR DESCRIPTION
According to https://stackoverflow.com/questions/53383352/spacy-and-spacy-models-in-setup-py this should fix it
The other fix option using setup.py in the project:
```
install_requires=[
    'spacy',
    'en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.0.0/en_core_web_sm-2.0.0.tar.gz',
],
```
is not a good idea if you intend to distribute your package on PyPI
`As a security measure, pip will raise an exception when installing packages from PyPI if those packages depend on packages not also hosted on PyPI. In the future, PyPI will block uploading packages with such external URL dependencies directly.`